### PR TITLE
Update `done` to `done-testing`

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -8,4 +8,4 @@ plan 1;
 
 is homoglyphs("A"), ("A", "Α", "А", "Ꭺ"), 'Calling homoglyphs() works ok';
 
-done;
+done-testing;


### PR DESCRIPTION
As of 6.c, what used to be called `done` in the test functions is now
called `done-testing`.  `done` is now used in the core Supplier class.

This change allows the test suite to pass again.