### PR TITLE
Add Travis-CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: perl6
+
+perl6:
+    - latest
+
+install:
+    - rakudobrew build-panda
+    - panda installdeps .


### PR DESCRIPTION
This allows the project to be automatically built and tested with the latest version of Perl6 on the [Travis-CI](https://travis-ci.org) continuous integration service.

Assuming that #2 is merged, this configuration will allow the tests on Travis to pass.