### PR TITLE
is export(*) is not a thing

### DIFF
--- a/lib/Text/Homoglyph.pm6
+++ b/lib/Text/Homoglyph.pm6
@@ -97,7 +97,7 @@ my %homoglyphs =
     '}' => "\xFF5D\xFE5C",
     '~' => "\xFF5E\x02DC\x2053\x223C";
 
-sub homoglyphs(Str $string where $string.chars == 1) is export(*) {
+sub homoglyphs(Str $string where $string.chars == 1) is export {
     return $string, |%homoglyphs{$string}.comb;
 }
 


### PR DESCRIPTION
That no longer works starting with this commit:
https://github.com/rakudo/rakudo/commit/1668b4f0b89912c8b9988661ce2b42572cb3cb88

I grepped the whole ecosystem and all chat logs, nobody ever wrote
something like that. I'm guessing that it is not supposed to work.